### PR TITLE
refactor: migrate server file system access to async/await

### DIFF
--- a/gift-wishlist/server/server.js
+++ b/gift-wishlist/server/server.js
@@ -1,7 +1,7 @@
 
 const express = require('express');
 const cors = require('cors');
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 
 const app = express();
@@ -18,27 +18,23 @@ const notifyAdmin = (suggestion) => {
 };
 
 // Endpoint to get all gifts
-app.get('/api/gifts', (req, res) => {
-  fs.readFile(giftsFilePath, 'utf8', (err, data) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).send('An error occurred while reading the gifts file.');
-    }
+app.get('/api/gifts', async (req, res) => {
+  try {
+    const data = await fs.readFile(giftsFilePath, 'utf8');
     res.json(JSON.parse(data));
-  });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('An error occurred while reading the gifts file.');
+  }
 });
 
 // Endpoint to reserve a gift
-app.post('/api/gifts/:id/reserve', (req, res) => {
+app.post('/api/gifts/:id/reserve', async (req, res) => {
   const giftId = parseInt(req.params.id, 10);
   const { name } = req.body;
 
-  fs.readFile(giftsFilePath, 'utf8', (err, data) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).send('An error occurred while reading the gifts file.');
-    }
-
+  try {
+    const data = await fs.readFile(giftsFilePath, 'utf8');
     let gifts = JSON.parse(data);
     const giftIndex = gifts.findIndex(g => g.id === giftId);
 
@@ -52,26 +48,20 @@ app.post('/api/gifts/:id/reserve', (req, res) => {
 
     gifts[giftIndex].reservedBy = name;
 
-    fs.writeFile(giftsFilePath, JSON.stringify(gifts, null, 2), (err) => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('An error occurred while saving the gifts file.');
-      }
-      res.json(gifts[giftIndex]);
-    });
-  });
+    await fs.writeFile(giftsFilePath, JSON.stringify(gifts, null, 2));
+    res.json(gifts[giftIndex]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('An error occurred while processing the request.');
+  }
 });
 
 // Endpoint to add a new gift
-app.post('/api/gifts', (req, res) => {
+app.post('/api/gifts', async (req, res) => {
   const { name, description, link, imageUrl, price, recipient } = req.body;
 
-  fs.readFile(giftsFilePath, 'utf8', (err, data) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).send('An error occurred while reading the gifts file.');
-    }
-
+  try {
+    const data = await fs.readFile(giftsFilePath, 'utf8');
     let gifts = JSON.parse(data);
     const newGift = {
       id: gifts.length > 0 ? Math.max(...gifts.map(g => g.id)) + 1 : 1,
@@ -85,50 +75,48 @@ app.post('/api/gifts', (req, res) => {
     };
 
     gifts.push(newGift);
-
-    fs.writeFile(giftsFilePath, JSON.stringify(gifts, null, 2), (err) => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('An error occurred while saving the gifts file.');
-      }
-      res.status(201).json(newGift);
-    });
-  });
+    await fs.writeFile(giftsFilePath, JSON.stringify(gifts, null, 2));
+    res.status(201).json(newGift);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('An error occurred while processing the gifts file.');
+  }
 });
 
 // Endpoint to suggest a new gift
-app.post('/api/suggestions', (req, res) => {
+app.post('/api/suggestions', async (req, res) => {
   const { name, description, link, imageUrl, price } = req.body;
 
-  fs.readFile(suggestionsFilePath, 'utf8', (err, data) => {
-    let suggestions = [];
-    if (!err) {
-      suggestions = JSON.parse(data);
-    } else if (err.code !== 'ENOENT') {
+  let suggestions = [];
+  try {
+    const data = await fs.readFile(suggestionsFilePath, 'utf8');
+    suggestions = JSON.parse(data);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
       console.error(err);
       return res.status(500).send('An error occurred while reading the suggestions file.');
     }
+  }
 
-    const newSuggestion = {
-      id: suggestions.length > 0 ? Math.max(...suggestions.map(s => s.id)) + 1 : 1,
-      name,
-      description,
-      link,
-      imageUrl,
-      price
-    };
+  const newSuggestion = {
+    id: suggestions.length > 0 ? Math.max(...suggestions.map(s => s.id)) + 1 : 1,
+    name,
+    description,
+    link,
+    imageUrl,
+    price
+  };
 
-    suggestions.push(newSuggestion);
+  suggestions.push(newSuggestion);
 
-    fs.writeFile(suggestionsFilePath, JSON.stringify(suggestions, null, 2), (err) => {
-      if (err) {
-        console.error(err);
-        return res.status(500).send('An error occurred while saving the suggestions file.');
-      }
-      notifyAdmin(newSuggestion);
-      res.status(202).json({ message: 'Suggestion received' });
-    });
-  });
+  try {
+    await fs.writeFile(suggestionsFilePath, JSON.stringify(suggestions, null, 2));
+    notifyAdmin(newSuggestion);
+    res.status(202).json({ message: 'Suggestion received' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('An error occurred while saving the suggestions file.');
+  }
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- replace callback-based fs usage with fs.promises
- make server route handlers async with try/catch for error handling

## Testing
- `CI=true npm test`
- `npm test` (server) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac95643b3c832fb4bea845f474cb8d