### PR TITLE
Add basic error handling for fetch requests

### DIFF
--- a/gift-wishlist/src/App.js
+++ b/gift-wishlist/src/App.js
@@ -16,8 +16,17 @@ function App() {
 
   useEffect(() => {
     fetch('http://localhost:3001/api/gifts')
-      .then(res => res.json())
-      .then(data => setGifts(data));
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return res.json();
+      })
+      .then(data => setGifts(data))
+      .catch(err => {
+        console.error('Error fetching gifts:', err);
+        alert('Die Geschenke konnten nicht geladen werden. Bitte versuche es später erneut.');
+      });
   }, []);
 
   const handleReserve = (id) => {
@@ -30,9 +39,18 @@ function App() {
         },
         body: JSON.stringify({ name }),
       })
-        .then(res => res.json())
+        .then(res => {
+          if (!res.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return res.json();
+        })
         .then(updatedGift => {
           setGifts(gifts.map(g => g.id === id ? updatedGift : g));
+        })
+        .catch(err => {
+          console.error('Error reserving gift:', err);
+          alert('Das Geschenk konnte nicht reserviert werden. Bitte versuche es später erneut.');
         });
     }
   };
@@ -48,22 +66,31 @@ function App() {
       recipient: newGiftRecipient,
     };
     fetch('http://localhost:3001/api/gifts', {
-
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(newGift),
     })
-    .then(() => {
-      setSuggestionMessage('Danke für deinen Vorschlag!');
-      setNewGiftName('');
-      setNewGiftDescription('');
-      setNewGiftLink('');
-      setNewGiftImageUrl('');
-      setNewGiftPrice('');
-      setNewGiftRecipient('eddy');
-    });
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return res;
+      })
+      .then(() => {
+        setSuggestionMessage('Danke für deinen Vorschlag!');
+        setNewGiftName('');
+        setNewGiftDescription('');
+        setNewGiftLink('');
+        setNewGiftImageUrl('');
+        setNewGiftPrice('');
+        setNewGiftRecipient('eddy');
+      })
+      .catch(err => {
+        console.error('Error suggesting gift:', err);
+        setSuggestionMessage('Beim Vorschlagen des Geschenks ist ein Fehler aufgetreten.');
+      });
 
   };
 


### PR DESCRIPTION
## Summary
- handle failed gift fetch calls with alerts
- show reservation and suggestion errors to users

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9563a6cc832fab7d7d08f2296dec